### PR TITLE
Fix right ear gain bug in hearing aid simulator and other compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/doxygen/output

--- a/3dti_ResourceManager/BRIR/BRIRFactory.cpp
+++ b/3dti_ResourceManager/BRIR/BRIRFactory.cpp
@@ -22,10 +22,10 @@
 
 #include <ostream>
 #include "BRIRFactory.h"
-#include <BinauralSpatializer/BRIR.h>
-#include <Common/ErrorHandler.h>
-#include <SOFA.h>
-#include <SOFAExceptions.h>
+#include "BinauralSpatializer/BRIR.h"
+#include "Common/ErrorHandler.h"
+#include "SOFA.h"
+#include "SOFAExceptions.h"
 #include <math.h>
 
 #define NORTH_AZIMUTH 0
@@ -153,6 +153,7 @@ namespace BRIR
 		{
 			SET_RESULT(RESULT_ERROR_UNKNOWN, "Unknown error when reading BRIR");
 		}
+        return -1;
 	}
 
 	//////////////////////////////////////////////////////////////////////

--- a/3dti_ResourceManager/HRTF/HRTFFactory.cpp
+++ b/3dti_ResourceManager/HRTF/HRTFFactory.cpp
@@ -22,10 +22,10 @@
 
 #include <ostream>
 #include "HRTFFactory.h"
-#include <BinauralSpatializer/HRTF.h>
-#include <Common/ErrorHandler.h>
-#include <SOFA.h>
-#include <SOFAExceptions.h>
+#include "BinauralSpatializer/HRTF.h"
+#include "Common/ErrorHandler.h"
+#include "SOFA.h"
+#include "SOFAExceptions.h"
 
 static inline const std::size_t array3DIndex(const unsigned long i,
                                              const unsigned long j,

--- a/3dti_Toolkit/HAHLSimulation/HearingAidSim.cpp
+++ b/3dti_Toolkit/HAHLSimulation/HearingAidSim.cpp
@@ -83,7 +83,7 @@ namespace HAHLSimulation {
 		}
 		if (ear == Common::T_ear::LEFT)
 			dynamicEqualizer.left.SetGains_dB(gains_dB);
-		if (ear == Common::T_ear::RIGHT);
+		if (ear == Common::T_ear::RIGHT)
 			dynamicEqualizer.right.SetGains_dB(gains_dB);
 	}
 


### PR DESCRIPTION
The hearing aid simulator bug has potentially serious implications, as I believe it means the gains for the right ear equalisation were never properly set. The other fixes are straightforward. 