### PR TITLE
Fix compile error in Xcode caused by function not returning a value

### DIFF
--- a/3dti_ResourceManager/BRIR/BRIRFactory.cpp
+++ b/3dti_ResourceManager/BRIR/BRIRFactory.cpp
@@ -153,6 +153,7 @@ namespace BRIR
 		{
 			SET_RESULT(RESULT_ERROR_UNKNOWN, "Unknown error when reading BRIR");
 		}
+        return -1;
 	}
 
 	//////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In cases where exception is thrown, `BRIR::GetSampleRateFromSofa` is not returning a value. This would previously have been a warning but now seems to be an error in the current version of Xcode.

This PR adds a -1 return value, similar to other failure modes.